### PR TITLE
Tags show longer contents when hovered

### DIFF
--- a/src/client/components/UserFactsheet.jsx
+++ b/src/client/components/UserFactsheet.jsx
@@ -17,7 +17,7 @@ export default function UserFactsheet(props) {
         </Media.Item>
       </Container>
 
-      <Container style={{ margin: 'auto' }}>
+      <Container className="availablity">
         <Media.Item>
           <Heading size={5}>
             <User username={username} />

--- a/src/client/components/__snapshots__/Availability.test.jsx.snap
+++ b/src/client/components/__snapshots__/Availability.test.jsx.snap
@@ -43,12 +43,8 @@ exports[`renders correctly 1`] = `
           </figure>
         </div>
         <div
-          className="container"
-          style={
-            Object {
-              "margin": "auto",
-            }
-          }
+          className="container availablity"
+          style={Object {}}
         >
           <div
             className="media-content"
@@ -122,12 +118,8 @@ exports[`renders correctly 1`] = `
           </figure>
         </div>
         <div
-          className="container"
-          style={
-            Object {
-              "margin": "auto",
-            }
-          }
+          className="container availablity"
+          style={Object {}}
         >
           <div
             className="media-content"

--- a/src/client/components/__snapshots__/UserFactsheet.test.jsx.snap
+++ b/src/client/components/__snapshots__/UserFactsheet.test.jsx.snap
@@ -26,12 +26,8 @@ exports[`renders correctly 1`] = `
     </figure>
   </div>
   <div
-    className="container"
-    style={
-      Object {
-        "margin": "auto",
-      }
-    }
+    className="container availablity"
+    style={Object {}}
   >
     <div
       className="media-content"

--- a/src/client/styles/components/Availabilities.scss
+++ b/src/client/styles/components/Availabilities.scss
@@ -1,10 +1,10 @@
 .c-availabilities {
     padding-bottom: 30px;
 
-    & .status-unknown {
+    .status-unknown {
         opacity: 0.3;
 
-        & .avatar:after {
+        .avatar:after {
             content: "keine Info";
             border-radius: 5px;
             border: 4px solid darkgrey;
@@ -23,7 +23,11 @@
         }
     }
 
-    & .tags .tag {
+    .tags {
+        align-items: flex-start;
+    }
+
+    .tags .tag {
         font-size: 15px;
     }
 }

--- a/src/client/styles/components/Tag.scss
+++ b/src/client/styles/components/Tag.scss
@@ -23,8 +23,18 @@
     &.wrapped {
         max-width: 200px;
         overflow: hidden;
-        overflow-wrap: break-word;
-        word-wrap: break-word;
         hyphens: auto;
+        white-space: nowrap;
+        text-overflow: ellipsis;
+
+        &:not(body) {
+            display: inline;
+            padding: 0.25em 0.75em;
+        }
+    
+        &:hover {
+            white-space: normal;
+            height: auto;
+        }
     }
 }


### PR DESCRIPTION
When a user adds more text than expected for a tag, the text is clipped when the tag is displayed. With this change the complete text is shown when a user hovers the mouse over the tag.