### PR TITLE
Fixed call to copyStatefulUrlToClipboard

### DIFF
--- a/src/client/components/Editor.jsx
+++ b/src/client/components/Editor.jsx
@@ -36,7 +36,9 @@ export default function Editor(props) {
         allowedModes={['tree', 'code', 'form', 'text']}
         onChange={state => onChange(state, copyStatefulUrlToClipboard(state))}
       />
-      <Button className="js-copy-url-to-clipboard" onClick={copyStatefulUrlToClipboard}>Copy diary page as URL</Button>
+      <Button className="js-copy-url-to-clipboard" onClick={() => copyStatefulUrlToClipboard(props.diaryPage)}>
+        Copy diary page as URL
+      </Button>
       <ReportFooter onClick={copyOnFooterClick} />
     </Container>
   );


### PR DESCRIPTION
The function needs the diaryPage structure as a parameter now, else the parameters in the URL would be empy.