### PR TITLE
Feature/wysiwyg

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 
 # misc
 .DS_Store
+.idea
 .env.local
 .env.development.local
 .env.test.local

--- a/src/client/components/Activity.jsx
+++ b/src/client/components/Activity.jsx
@@ -78,7 +78,6 @@ export default function ActivityItems(props) {
             {contentEditable
             && (
               <ActivityItem
-                key="__new__"
                 title=" "
                 contentEditable
                 updateValue={content => updateValue(titledItems.length, content)}

--- a/src/client/components/Activity.jsx
+++ b/src/client/components/Activity.jsx
@@ -1,31 +1,31 @@
-import React from 'react';
-import {PropTypes} from 'prop-types';
+import React, { Fragment } from 'react';
+import { PropTypes } from 'prop-types';
 
 import Heading from 'react-bulma-components/lib/components/heading';
 import Box from 'react-bulma-components/lib/components/box';
-import Content from 'react-bulma-components/lib/components/content';
 
-import Container from 'react-bulma-components/lib/components/container';
-import {activityItemType} from '../../models/activityItemType';
+import { activityItemType } from '../../models/activityItemType';
 import MarkDown from './Markdown';
 import User from './User';
 
-import {TeamContext} from '../lib/teamContext';
+import { TeamContext } from '../lib/teamContext';
 
 function ActivityItem(props) {
   const {
     title, owners, contentEditable, updateValue
   } = props;
 
+  const separator = <Fragment>,&nbsp;</Fragment>;
   const listOfOwners = owners && (
     <span>
       &nbsp;(
       {owners.map((owner, i) => (
         <span key={owner}>
-          {(i && ', ')}
+          {i > 0 ? separator : ''}
           <User username={owner} />
         </span>
       ))}
+      )
     </span>
   );
 

--- a/src/client/components/Activity.jsx
+++ b/src/client/components/Activity.jsx
@@ -1,40 +1,47 @@
 import React from 'react';
-import { PropTypes } from 'prop-types';
+import {PropTypes} from 'prop-types';
 
 import Heading from 'react-bulma-components/lib/components/heading';
 import Box from 'react-bulma-components/lib/components/box';
 import Content from 'react-bulma-components/lib/components/content';
 
 import Container from 'react-bulma-components/lib/components/container';
-import { activityItemType } from '../../models/activityItemType';
+import {activityItemType} from '../../models/activityItemType';
 import MarkDown from './Markdown';
 import User from './User';
 
-import { TeamContext } from '../lib/teamContext';
+import {TeamContext} from '../lib/teamContext';
 
 function ActivityItem(props) {
-  const { title, owners } = props;
+  const {
+    title, owners, contentEditable, updateValue
+  } = props;
+
+  const listOfOwners = owners && (
+    <span>
+      &nbsp;(
+      {owners.map((owner, i) => (
+        <span key={owner}>
+          {(i && ', ')}
+          <User username={owner} />
+        </span>
+      ))}
+    </span>
+  );
+
   return (
     <li key={title}>
       <TeamContext.Consumer>
-        {teamContext => <MarkDown code={title || ''} serverUrl={teamContext.serverUrl} />}
+        {teamContext => (
+          <MarkDown
+            contentEditable={contentEditable}
+            updateValue={updateValue}
+            code={title || ''}
+            serverUrl={teamContext.serverUrl}
+          />
+        )}
       </TeamContext.Consumer>
-      {owners
-        && (
-          <Container renderAs="span">
-            <Content renderAs="span">&nbsp;(</Content>
-            {owners.map((owner, i) => (
-              <Container key={owner} renderAs="span">
-                <User username={owner} />
-                {owners.length > 1 && i !== (owners.length - 1)
-                  && <Content renderAs="span">,&nbsp;</Content>
-                }
-              </Container>
-            ))}
-            <Content renderAs="span">)</Content>
-          </Container>
-        )
-      }
+      {listOfOwners}
     </li>
   );
 }
@@ -47,7 +54,7 @@ ActivityItem.propTypes = activityItemType;
 
 export default function ActivityItems(props) {
   const {
-    title, list, className
+    title, list, className, contentEditable, updateValue
   } = props;
 
   const titledItems = list.filter(item => item.title);
@@ -58,14 +65,25 @@ export default function ActivityItems(props) {
       {titledItems.length > 0
         ? (
           <ul>
-            {titledItems.map(item => (
+            {titledItems.map((item, liIndex) => (
               <ActivityItem
                 key={item.title}
                 title={item.title}
                 details={item.details}
                 owners={item.owners}
+                contentEditable={contentEditable}
+                updateValue={content => updateValue(liIndex, content)}
               />
             ))}
+            {contentEditable
+            && (
+              <ActivityItem
+                key="__new__"
+                title=" "
+                contentEditable
+                updateValue={content => updateValue(titledItems.length, content)}
+              />
+            )}
           </ul>
         )
         : <div className="empty-items">-</div>
@@ -81,5 +99,7 @@ ActivityItems.defaultProps = {
 ActivityItems.propTypes = {
   title: PropTypes.string.isRequired,
   list: PropTypes.arrayOf(PropTypes.shape(activityItemType)),
-  className: PropTypes.string.isRequired
+  className: PropTypes.string.isRequired,
+  contentEditable: PropTypes.bool,
+  updateValue: PropTypes.func
 };

--- a/src/client/components/Activity.test.jsx
+++ b/src/client/components/Activity.test.jsx
@@ -12,6 +12,8 @@ it('renders a list correctly', () => {
           { title: 'sample title 2', details: 'sample details' },
         ]}
         className="sample"
+        contentEditable={false}
+        updateValue={() => {}}
       />
     )
     .toJSON();
@@ -25,6 +27,8 @@ it('does not render an empty list', () => {
         title="empty"
         list={[]}
         className="sample"
+        contentEditable={false}
+        updateValue={() => {}}
       />
     )
     .toJSON();
@@ -38,6 +42,8 @@ it('does not render a list without titled items', () => {
         title="no-title"
         list={[{ title: '' }]}
         className="sample"
+        contentEditable={false}
+        updateValue={() => {}}
       />
     )
     .toJSON();

--- a/src/client/components/Availability.jsx
+++ b/src/client/components/Availability.jsx
@@ -8,7 +8,9 @@ import UserFactsheet from './UserFactsheet';
 
 export default function Availabilities(props) {
   const {
-    members
+    members,
+    contentEditable,
+    updateValue
   } = props;
 
   return (
@@ -23,7 +25,11 @@ export default function Availabilities(props) {
             size={4}
             className={member.statusKnown ? 'status-known' : 'status-unknown'}
           >
-            <UserFactsheet username={member.username}>
+            <UserFactsheet
+              username={member.username}
+              contentEditable={contentEditable}
+              updateValue={updateValue}
+            >
               <Tag.Group>
                 {member.statusKnown && member.blocked
                 && <Tag className="blocked">Blockiert</Tag>
@@ -33,6 +39,9 @@ export default function Availabilities(props) {
                 <Tag
                   color="primary"
                   className="wrapped"
+                  contentEditable={contentEditable}
+                  suppressContentEditableWarning
+                  onBlur={e => updateValue(member.username, 'future.availability', e.target.innerHTML)}
                 >
                   {member.availability}
                 </Tag>
@@ -54,5 +63,7 @@ Availabilities.propTypes = {
     statusKnown: PropTypes.bool.isRequired,
     availability: PropTypes.string.isRequired,
     blocked: PropTypes.bool
-  })).isRequired
+  })).isRequired,
+  contentEditable: PropTypes.bool.isRequired,
+  updateValue: PropTypes.func.isRequired
 };

--- a/src/client/components/Availability.jsx
+++ b/src/client/components/Availability.jsx
@@ -27,6 +27,7 @@ export default function Availabilities(props) {
           >
             <UserFactsheet
               username={member.username}
+              statusKnown={member.statusKnown}
               contentEditable={contentEditable}
               updateValue={updateValue}
             >

--- a/src/client/components/Availability.test.jsx
+++ b/src/client/components/Availability.test.jsx
@@ -20,6 +20,8 @@ it('renders correctly', () => {
             blocked: false
           },
         ]}
+        contentEditable={false}
+        updateValue={() => {}}
       />
     )
     .toJSON();

--- a/src/client/components/DetailsAggregated.jsx
+++ b/src/client/components/DetailsAggregated.jsx
@@ -47,6 +47,8 @@ export default function DetailsAggregated(props) {
         title="Geplante Tätigkeiten"
         list={aggregatedMultipleOwners}
         className="next"
+        contentEditable={false}
+        updateValue={() => {}}
       />
     </Section>
     )

--- a/src/client/components/DetailsByMember.jsx
+++ b/src/client/components/DetailsByMember.jsx
@@ -9,7 +9,7 @@ import MemberReport from './MemberReport';
 import { memberReportType } from '../../models/memberReportType';
 
 export default function DetailsByMember(props) {
-  const { teamReport } = props;
+  const { teamReport, contentEditable, updateValue } = props;
   return (
     <Section className="c-past">
       <Heading size={3}>Was los war</Heading>
@@ -25,6 +25,8 @@ export default function DetailsByMember(props) {
               plannedAvailability={memberReport.future.availability}
               past={memberReport.past}
               future={memberReport.future}
+              contentEditable={contentEditable}
+              updateValue={updateValue}
             />
           ))}
       </Columns>
@@ -33,5 +35,7 @@ export default function DetailsByMember(props) {
 }
 
 DetailsByMember.propTypes = {
-  teamReport: PropTypes.arrayOf(PropTypes.shape(memberReportType)).isRequired
+  teamReport: PropTypes.arrayOf(PropTypes.shape(memberReportType)).isRequired,
+  contentEditable: PropTypes.bool.isRequired,
+  updateValue: PropTypes.func.isRequired
 };

--- a/src/client/components/DiaryPage.jsx
+++ b/src/client/components/DiaryPage.jsx
@@ -94,7 +94,11 @@ export default class DiaryPage extends Component {
           updateValue={(username, fieldName, value) => updateMember(username, fieldName, value)}
         />
         <DetailsAggregated teamReport={teamReport} />
-        <DetailsByMember teamReport={teamReport} />
+        <DetailsByMember
+          teamReport={teamReport}
+          contentEditable={contentEditable}
+          updateValue={(username, fieldName, value) => updateMember(username, fieldName, value)}
+        />
       </Container>
     );
   }

--- a/src/client/components/DiaryPage.jsx
+++ b/src/client/components/DiaryPage.jsx
@@ -15,37 +15,86 @@ import isBlocked from '../lib/isBlocked';
 export default class DiaryPage extends Component {
   static propTypes = dailyType;
 
-  constructor(props) {
-    super(props);
-
-    this.date = props.date;
-    this.teamName = props.teamName;
-    this.teamReport = props.teamReport;
+  updateDate(dateString) {
+    const { props: { updateValue } } = this;
+    const date = new Date(dateString);
+    if (!Number.isNaN(date)) {
+      updateValue('date', date);
+    }
   }
 
   render() {
+    const {
+      props: {
+        updateValue,
+        contentEditable,
+        date,
+        teamName,
+        teamReport,
+        serverUrl
+      }
+    } = this;
+
+    function updateMember(username, fieldName, value) {
+      updateValue('teamReport', teamReport.map((member) => {
+        if (username === member.username) {
+          const path = fieldName.split('.');
+          let current = member;
+          while (path.length > 1) {
+            current = current[path.shift()];
+          }
+          current[path.shift()] = value;
+        }
+        return member;
+      }));
+    }
+
+    const urlField = contentEditable && (
+      <div
+        className="serverUrl"
+        contentEditable
+        suppressContentEditableWarning
+        onBlur={e => updateValue('serverUrl', e.target.innerText)}
+      >
+        {serverUrl}
+      </div>);
+
     return (
       <Container>
         <Hero className="diary-page" color="primary">
           <Hero.Body>
-            <Heading className="team-name">
-              {this.teamName}
+            {urlField}
+            <Heading
+              contentEditable={contentEditable}
+              suppressContentEditableWarning
+              className="team-name"
+              onBlur={e => updateValue('teamName', e.target.innerHTML)}
+            >
+              {teamName}
             </Heading>
-            <Heading subtitle className="date">
-              {dateFormat(this.date, 'dddd, dd. mmmm')}
+            <Heading
+              subtitle
+              className="date"
+              contentEditable={contentEditable}
+              suppressContentEditableWarning
+              onBlur={e => this.updateDate(e.target.innerHTML)}
+            >
+              {dateFormat(date, 'dddd, dd. mmmm yyyy')}
             </Heading>
           </Hero.Body>
         </Hero>
         <Availabilities
-          members={this.teamReport.map(memberReport => ({
+          members={teamReport.map(memberReport => ({
             username: memberReport.username,
             availability: memberReport.future.availability,
             statusKnown: memberReport.statusKnown,
             blocked: isBlocked(memberReport.past.blockingItems)
           }))}
+          contentEditable={contentEditable}
+          updateValue={(username, fieldName, value) => updateMember(username, fieldName, value)}
         />
-        <DetailsAggregated teamReport={this.teamReport} />
-        <DetailsByMember teamReport={this.teamReport} />
+        <DetailsAggregated teamReport={teamReport} />
+        <DetailsByMember teamReport={teamReport} />
       </Container>
     );
   }

--- a/src/client/components/Markdown.jsx
+++ b/src/client/components/Markdown.jsx
@@ -23,11 +23,16 @@ export default function Markdown(props) {
     return { __html: markDown.render(handleMentions(code)) };
   }
 
-  const { code, withBreaks } = props;
+  const {
+    code, withBreaks, contentEditable, updateValue
+  } = props;
   return (
-    <span dangerouslySetInnerHTML={withBreaks // eslint-disable-line react/no-danger
-      ? createMarkup(code)
-      : createMarkupInline(code)
+    <div
+      contentEditable={contentEditable}
+      onBlur={event => updateValue(event.target.innerText)}
+      dangerouslySetInnerHTML={withBreaks // eslint-disable-line react/no-danger
+        ? createMarkup(code)
+        : createMarkupInline(code)
     }
     />
   );
@@ -40,5 +45,7 @@ Markdown.defaultProps = {
 Markdown.propTypes = {
   code: PropTypes.string.isRequired,
   withBreaks: PropTypes.bool,
-  serverUrl: PropTypes.string.isRequired
+  serverUrl: PropTypes.string.isRequired,
+  contentEditable: PropTypes.bool.isRequired,
+  updateValue: PropTypes.func.isRequired
 };

--- a/src/client/components/MemberReport.jsx
+++ b/src/client/components/MemberReport.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { PropTypes } from 'prop-types';
 
 import Card from 'react-bulma-components/lib/components/card';
 import Columns from 'react-bulma-components/lib/components/columns';
@@ -14,7 +15,7 @@ import isBlocked from '../lib/isBlocked';
 
 export default function MemberReport(props) {
   const {
-    username, past, statusKnown, future
+    username, past, statusKnown, future, contentEditable, updateValue
   } = props;
   const { workingOnItems, completedItems, blockingItems } = past;
   const { plannedItems } = future;
@@ -37,8 +38,21 @@ export default function MemberReport(props) {
                 <Tag size="medium" className="blocked">
                   Blockiert
                 </Tag>
-              )
-            }
+              )}
+              { contentEditable
+              && (
+                <div>
+                  <input
+                    type="checkbox"
+                    checked={isBlocked(blockingItems)}
+                    onChange={(event) => {
+                      const value = event.target.checked ? [{ title: 'Ich brauche...' }] : undefined;
+                      updateValue(username, 'past.blockingItems', value);
+                    }}
+                  />
+                  &nbsp; blockiert
+                </div>
+              )}
             </Tag.Group>
           </Card.Header>
           <Card.Content>
@@ -48,23 +62,43 @@ export default function MemberReport(props) {
                 title="Blockiert"
                 list={blockingItems}
                 className="blocking"
+                contentEditable={contentEditable}
+                updateValue={(liIndex, title) => {
+                  blockingItems[liIndex] = { title };
+                  updateValue(username, 'past.blockingItems', blockingItems);
+                }}
               />
               )}
             <ActivityItems
               title="Erledigt"
               list={completedItems}
               className="completed"
+              contentEditable={contentEditable}
+              updateValue={(liIndex, title) => {
+                completedItems[liIndex] = { title };
+                updateValue(username, 'past.completedItems', completedItems);
+              }}
             />
             <ActivityItems
               title="Arbeitet an"
               list={workingOnItems}
               className="worked-on"
+              contentEditable={contentEditable}
+              updateValue={(liIndex, title) => {
+                workingOnItems[liIndex] = { title };
+                updateValue(username, 'past.workingOnItems', workingOnItems);
+              }}
             />
 
             <ActivityItems
               title="Geplant"
               list={plannedItems}
               className="planned"
+              contentEditable={contentEditable}
+              updateValue={(liIndex, title) => {
+                plannedItems[liIndex] = { title };
+                updateValue(username, 'future.plannedItems', plannedItems);
+              }}
             />
           </Card.Content>
         </Card>
@@ -84,4 +118,7 @@ export default function MemberReport(props) {
     </Columns.Column>);
 }
 
-MemberReport.propTypes = memberReportType;
+MemberReport.propTypes = Object.assign({
+  contentEditable: PropTypes.bool.isRequired,
+  updateValue: PropTypes.func.isRequired
+}, memberReportType);

--- a/src/client/components/UserFactsheet.jsx
+++ b/src/client/components/UserFactsheet.jsx
@@ -8,7 +8,23 @@ import Avatar from './Avatar';
 
 
 export default function UserFactsheet(props) {
-  const { username, children } = props;
+  const {
+    username,
+    children,
+    contentEditable,
+    updateValue
+  } = props;
+
+  const statusKnownCheckbox = contentEditable && (
+    <div className="statusKnownCheckbox">
+      <input
+        type="checkbox"
+        onChange={e => updateValue(username, 'statusKnown', e.target.checked)}
+      />
+      &nbsp;provided info
+    </div>
+  );
+
   return (
     <Media>
       <Container>
@@ -22,6 +38,7 @@ export default function UserFactsheet(props) {
           <Heading size={5}>
             <User username={username} />
           </Heading>
+          {statusKnownCheckbox}
           <Container>{children}</Container>
         </Media.Item>
       </Container>
@@ -38,5 +55,7 @@ UserFactsheet.propTypes = {
   children: PropTypes.oneOfType([
     PropTypes.arrayOf(PropTypes.node),
     PropTypes.node
-  ])
+  ]),
+  contentEditable: PropTypes.bool.isRequired,
+  updateValue: PropTypes.func.isRequired
 };

--- a/src/client/components/UserFactsheet.jsx
+++ b/src/client/components/UserFactsheet.jsx
@@ -11,6 +11,7 @@ export default function UserFactsheet(props) {
   const {
     username,
     children,
+    statusKnown,
     contentEditable,
     updateValue
   } = props;
@@ -19,6 +20,7 @@ export default function UserFactsheet(props) {
     <div className="statusKnownCheckbox">
       <input
         type="checkbox"
+        checked={statusKnown}
         onChange={e => updateValue(username, 'statusKnown', e.target.checked)}
       />
       &nbsp;provided info
@@ -56,6 +58,7 @@ UserFactsheet.propTypes = {
     PropTypes.arrayOf(PropTypes.node),
     PropTypes.node
   ]),
+  statusKnown: PropTypes.bool.isRequired,
   contentEditable: PropTypes.bool.isRequired,
   updateValue: PropTypes.func.isRequired
 };

--- a/src/client/components/UserFactsheet.test.jsx
+++ b/src/client/components/UserFactsheet.test.jsx
@@ -4,7 +4,7 @@ import UserFactsheet from './UserFactsheet';
 
 it('renders correctly', () => {
   const tree = renderer
-    .create(<UserFactsheet username="testuser" contentEditable={false} updateValue={() => {}}>
+    .create(<UserFactsheet username="testuser" statusKnown contentEditable={false} updateValue={() => {}}>
       <div className="sampleChild">sample Child should be rendered</div>
             </UserFactsheet>)
     .toJSON();

--- a/src/client/components/UserFactsheet.test.jsx
+++ b/src/client/components/UserFactsheet.test.jsx
@@ -4,7 +4,7 @@ import UserFactsheet from './UserFactsheet';
 
 it('renders correctly', () => {
   const tree = renderer
-    .create(<UserFactsheet username="testuser">
+    .create(<UserFactsheet username="testuser" contentEditable={false} updateValue={() => {}}>
       <div className="sampleChild">sample Child should be rendered</div>
             </UserFactsheet>)
     .toJSON();

--- a/src/client/components/__snapshots__/Activity.test.jsx.snap
+++ b/src/client/components/__snapshots__/Activity.test.jsx.snap
@@ -16,21 +16,25 @@ exports[`renders a list correctly 1`] = `
   </h1>
   <ul>
     <li>
-      <span
+      <div
+        contentEditable={false}
         dangerouslySetInnerHTML={
           Object {
             "__html": "sample title 1",
           }
         }
+        onBlur={[Function]}
       />
     </li>
     <li>
-      <span
+      <div
+        contentEditable={false}
         dangerouslySetInnerHTML={
           Object {
             "__html": "sample title 2",
           }
         }
+        onBlur={[Function]}
       />
     </li>
   </ul>

--- a/src/client/components/__snapshots__/Availability.test.jsx.snap
+++ b/src/client/components/__snapshots__/Availability.test.jsx.snap
@@ -78,7 +78,10 @@ exports[`renders correctly 1`] = `
                 </span>
                 <span
                   className="tag wrapped is-primary"
+                  contentEditable={false}
+                  onBlur={[Function]}
                   style={Object {}}
+                  suppressContentEditableWarning={true}
                 >
                   here
                 </span>

--- a/src/client/components/__snapshots__/DetailsAggregated.test.jsx.snap
+++ b/src/client/components/__snapshots__/DetailsAggregated.test.jsx.snap
@@ -33,7 +33,7 @@ exports[`aggregates correctly 1`] = `
         <span>
            (
           <span>
-            0
+            
             <a
               className="c-user"
               href="/direct/user1"
@@ -44,7 +44,7 @@ exports[`aggregates correctly 1`] = `
             </a>
           </span>
           <span>
-            , 
+            , 
             <a
               className="c-user"
               href="/direct/user2"
@@ -54,6 +54,7 @@ exports[`aggregates correctly 1`] = `
               @user2
             </a>
           </span>
+          )
         </span>
       </li>
     </ul>

--- a/src/client/components/__snapshots__/DetailsAggregated.test.jsx.snap
+++ b/src/client/components/__snapshots__/DetailsAggregated.test.jsx.snap
@@ -21,27 +21,19 @@ exports[`aggregates correctly 1`] = `
     </h1>
     <ul>
       <li>
-        <span
+        <div
+          contentEditable={false}
           dangerouslySetInnerHTML={
             Object {
               "__html": "planned 1",
             }
           }
+          onBlur={[Function]}
         />
-        <span
-          className="container"
-          style={Object {}}
-        >
-          <span
-            className="content"
-            style={Object {}}
-          >
-             (
-          </span>
-          <span
-            className="container"
-            style={Object {}}
-          >
+        <span>
+           (
+          <span>
+            0
             <a
               className="c-user"
               href="/direct/user1"
@@ -50,17 +42,9 @@ exports[`aggregates correctly 1`] = `
             >
               @user1
             </a>
-            <span
-              className="content"
-              style={Object {}}
-            >
-              , 
-            </span>
           </span>
-          <span
-            className="container"
-            style={Object {}}
-          >
+          <span>
+            , 
             <a
               className="c-user"
               href="/direct/user2"
@@ -69,12 +53,6 @@ exports[`aggregates correctly 1`] = `
             >
               @user2
             </a>
-          </span>
-          <span
-            className="content"
-            style={Object {}}
-          >
-            )
           </span>
         </span>
       </li>

--- a/src/client/styles/components/Activity.scss
+++ b/src/client/styles/components/Activity.scss
@@ -13,11 +13,7 @@
     }
     & li {
         margin-bottom: 10px;
-        margin-left: 20px;
-
-        // Indent after the second line
         padding-left: 1.5em;
-        text-indent:-1.5em;
     }
 }
 

--- a/src/client/styles/components/Tag.scss
+++ b/src/client/styles/components/Tag.scss
@@ -24,14 +24,14 @@
         max-width: 200px;
         overflow: hidden;
         hyphens: auto;
-        white-space: nowrap;
+        white-space: normal;
         text-overflow: ellipsis;
 
         &:not(body) {
             display: inline;
             padding: 0.25em 0.75em;
         }
-    
+
         &:hover {
             white-space: normal;
             height: auto;

--- a/src/client/styles/index.scss
+++ b/src/client/styles/index.scss
@@ -10,5 +10,13 @@
 @import './components/Editor.scss';
 @import './components/MemberReport.scss';
 
+.serverUrl {
+  float: right;
+}
+
+.statusKnownCheckbox {
+  margin: -1.5em 0 1.5em;
+}
+
 // elements which properties are overridden
 @import './objects/section.scss';

--- a/src/models/activityItemType.js
+++ b/src/models/activityItemType.js
@@ -3,5 +3,7 @@ import { PropTypes } from 'prop-types';
 export const activityItemType = {
   title: PropTypes.string.isRequired,
   details: PropTypes.string,
-  owners: PropTypes.arrayOf(PropTypes.string)
+  owners: PropTypes.arrayOf(PropTypes.string),
+  contentEditable: PropTypes.bool,
+  updateValue: PropTypes.func
 };


### PR DESCRIPTION
What-you-see-is-what-you-get editor for the diary page.

If you add an `edit=true` URL parameter, the page is shown in edit mode, so that you can just click in (most of) the texts to modify the data structure immediately. The URL is adapted after leaving a changed field, so that you can copy it at any time.

Keep in mind, that the `edit` Parameter gets lost, whenever you switch to the 'old' JSON editor page.