### PR TITLE
Implicitly consider feedback provided when editing

### DIFF
--- a/src/client/components/UserFactsheet.jsx
+++ b/src/client/components/UserFactsheet.jsx
@@ -95,7 +95,20 @@ export default class UserFactsheet extends React.Component {  // eslint-disable-
     );
 
     const converterButton = contentEditable && (
-      <button type="button" className="converterButton" onClick={() => this.setState({ popupVisible: true })}>✎</button>
+      <button
+        type="button"
+        className="converterButton"
+        onClick={() => {
+          updateValue(member.username, 'statusKnown', true); // one someone edits the text, it's because a status is known
+          this.setState({
+            popupVisible: true
+          });
+        }
+      }
+      >
+✎
+
+      </button>
     );
 
     return (
@@ -105,7 +118,7 @@ export default class UserFactsheet extends React.Component {  // eslint-disable-
         </Media.Item>
 
         <div className="factSheetInfo">
-          { converterButton }
+          {converterButton}
           <Heading size={5}>
             <User username={member.username} />
           </Heading>

--- a/src/client/components/UserFactsheet.jsx
+++ b/src/client/components/UserFactsheet.jsx
@@ -99,15 +99,13 @@ export default class UserFactsheet extends React.Component {  // eslint-disable-
         type="button"
         className="converterButton"
         onClick={() => {
-          updateValue(member.username, 'statusKnown', true); // one someone edits the text, it's because a status is known
+          updateValue(member.username, 'statusKnown', true); // once someone edits the text, it's because a status is known
           this.setState({
             popupVisible: true
           });
-        }
-      }
+        }}
       >
-✎
-
+        ✎
       </button>
     );
 


### PR DESCRIPTION
When editing a user's status, the "info prvided" is now automatically being set