### PR TITLE
Show screenshot button only in edit mode

### DIFF
--- a/src/client/components/DiaryPage.jsx
+++ b/src/client/components/DiaryPage.jsx
@@ -100,7 +100,10 @@ export default class DiaryPage extends Component {
             </Heading>
 
           </Hero.Body>
-          <span id="screenshot-button" role="button" aria-label="Take Screenshot" onClick={e => downloadScreenshot(e.target)}>📷</span>
+          {contentEditable && (
+            <button type="button" id="screenshot-button" onClick={e => downloadScreenshot(e.target)}>
+              <span role="img" aria-label="Screenshot">📷</span>
+            </button>)}
         </Hero>
         <Availabilities
           members={teamReport}

--- a/src/client/styles/index.scss
+++ b/src/client/styles/index.scss
@@ -27,8 +27,8 @@
   height: 30px;
   text-align: center;
   border-radius: 50%;
-  line-height: 1.4em;
-  text-indent: 4px;
+  line-height: 1em;
+  text-indent: -4px;
   font-size: 20px;
 
   &:hover {


### PR DESCRIPTION
The screenshot button is currently not used and therefore should not be visible at least in view mode.