### PR TITLE
Refactored the diary parser and made it available as a library

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,5 @@
+const DiaryParser = require('./src/client/lib/diaryParser');
+
+module.exports = {
+  DiaryParser
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "assistify-daily",
+  "name": "assistify-diary",
   "version": "0.0.1",
   "lockfileVersion": 1,
   "requires": true,
@@ -6382,7 +6382,7 @@
     },
     "finalhandler": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
+      "resolved": "http://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
       "integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
       "dev": true,
       "requires": {
@@ -7811,7 +7811,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "requires": {
@@ -7826,7 +7826,7 @@
         },
         "string_decoder": {
           "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "dev": true,
           "requires": {
@@ -7947,7 +7947,7 @@
     },
     "http-errors": {
       "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+      "resolved": "http://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
       "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
       "dev": true,
       "requires": {
@@ -7976,7 +7976,7 @@
     },
     "http-proxy-middleware": {
       "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.18.0.tgz",
+      "resolved": "http://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.18.0.tgz",
       "integrity": "sha512-Fs25KVMPAIIcgjMZkVHJoKg9VcXcC1C8yb9JUgeDvVXY0S/zgVIhMb+qVswDIgtJe2DfckMSY2d6TuTEutlk6Q==",
       "dev": true,
       "requires": {
@@ -10658,7 +10658,7 @@
     },
     "media-typer": {
       "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "resolved": "http://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
       "dev": true
     },
@@ -12579,7 +12579,7 @@
       "dependencies": {
         "async": {
           "version": "1.5.2",
-          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+          "resolved": "http://registry.npmjs.org/async/-/async-1.5.2.tgz",
           "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
           "dev": true
         },

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "assistify-daily",
+  "name": "assistify-diary",
   "version": "0.0.1",
   "description": "A simple team diary",
   "keywords": [],

--- a/src/client/lib/diaryParser.test.js
+++ b/src/client/lib/diaryParser.test.js
@@ -1,15 +1,17 @@
-import parser from './diaryParser';
+import DiaryParser from './diaryParser';
 
-const simpleText = `**An was hast Du gearbeitet?**
+const parser = new DiaryParser();
+
+const simpleText = `**${parser.questions[0]}?**
 - task 1
 
-**Was möchtest Du als Nächstes tun?**
+**${parser.questions[1]}?**
 - task 3
 
-**Kommst Du bei etwas nicht weiter und brauchst Hilfe?**
+**${parser.questions[2]}?**
 - task 2
 
-**Wo verbringst Du Deinen nächsten Arbeitstag?**
+**${parser.questions[3]}?**
 Office`;
 
 const simpleStructure = {
@@ -33,7 +35,8 @@ describe('Parser', () => {
   });
 
   it('should report errors when text outside of the template is given', () => {
-    expect(parser.parse('abc\ndef')).toEqual({
+    const newParser = new DiaryParser();
+    expect(newParser.parse('abc\ndef')).toEqual({
       future: { availability: 'unbekannt', plannedItems: [] },
       past: { blockingItems: [], completedItems: [] },
       notRecognized: 'abc\ndef'
@@ -42,6 +45,18 @@ describe('Parser', () => {
 
   it('should display unformatted text below the template with a caption', () => {
     expect(parser.renderAsText(Object.assign({ notRecognized: 'abc\ndef' }, simpleStructure)))
-      .toEqual(`${simpleText}\n\n**NOT RECOGNIZED**\nabc\ndef`);
+      .toEqual(`${simpleText}\n&nbsp;\n**NOT RECOGNIZED**\nabc\ndef`);
+  });
+
+  it('should ignore case of messages', () => {
+    const newParser = new DiaryParser();
+    const capitalizeEveryWord = text => text.toLowerCase()
+      .split(' ')
+      .map(s => s.charAt(0).toUpperCase() + s.substring(1))
+      .join(' ');
+    expect(newParser.parse(`**${capitalizeEveryWord(newParser.questions[0])}?**\nqwert`)).toEqual({
+      future: { availability: 'unbekannt', plannedItems: [] },
+      past: { blockingItems: [], completedItems: [{ title: 'qwert' }] }
+    });
   });
 });


### PR DESCRIPTION
The diaryParser needs to be used in the operations tool. To prevent code duplication I made this repo available as a library by exporting the diaryParser in the main module.

Additionally I refactored the diaryParser to reduce duplication of message texts.