### PR TITLE
Refactor parser library

### DIFF
--- a/src/client/lib/diaryParser.test.js
+++ b/src/client/lib/diaryParser.test.js
@@ -26,6 +26,9 @@ const simpleStructure = {
   notRecognized: ''
 };
 
+const simpleWithUnrecognized = Object.assign({}, simpleStructure, { notRecognized: 'abc\ndef' });
+const simpleWithUnrecognizedText = `${simpleText}\n&nbsp;\n**NOT RECOGNIZED**\nabc\ndef`;
+
 describe('Parser', () => {
   it('should correctly serialize the data structure', () => {
     expect(parser.renderAsText(simpleStructure)).toEqual(simpleText);
@@ -45,10 +48,8 @@ describe('Parser', () => {
   });
 
   it('should display unformatted text below the template with a caption', () => {
-    const simpleWithUnrecognized = simpleStructure;
-    simpleWithUnrecognized.notRecognized = 'abc\ndef';
     expect(parser.renderAsText(simpleWithUnrecognized))
-      .toEqual(`${simpleText}\n&nbsp;\n**NOT RECOGNIZED**\nabc\ndef`);
+      .toEqual(simpleWithUnrecognizedText);
   });
 
   it('should ignore case of messages', () => {
@@ -62,5 +63,11 @@ describe('Parser', () => {
       past: { blockingItems: [], completedItems: [{ title: 'qwert' }] },
       notRecognized: '',
     });
+  });
+
+  it('should allow re-use', () => {
+    expect(parser.renderAsText(simpleStructure)).toEqual(simpleText);
+    expect(parser.renderAsText(simpleWithUnrecognized)).toEqual(simpleWithUnrecognizedText);
+    expect(parser.renderAsText(simpleStructure)).toEqual(simpleText);
   });
 });

--- a/src/client/lib/diaryParser.test.js
+++ b/src/client/lib/diaryParser.test.js
@@ -21,8 +21,9 @@ const simpleStructure = {
   },
   future: {
     plannedItems: [{ title: 'task 3' }],
-    availability: 'Office'
-  }
+    availability: 'Office',
+  },
+  notRecognized: ''
 };
 
 describe('Parser', () => {
@@ -44,7 +45,9 @@ describe('Parser', () => {
   });
 
   it('should display unformatted text below the template with a caption', () => {
-    expect(parser.renderAsText(Object.assign({ notRecognized: 'abc\ndef' }, simpleStructure)))
+    const simpleWithUnrecognized = simpleStructure;
+    simpleWithUnrecognized.notRecognized = 'abc\ndef';
+    expect(parser.renderAsText(simpleWithUnrecognized))
       .toEqual(`${simpleText}\n&nbsp;\n**NOT RECOGNIZED**\nabc\ndef`);
   });
 
@@ -56,7 +59,8 @@ describe('Parser', () => {
       .join(' ');
     expect(newParser.parse(`**${capitalizeEveryWord(newParser.questions[0])}?**\nqwert`)).toEqual({
       future: { availability: 'unbekannt', plannedItems: [] },
-      past: { blockingItems: [], completedItems: [{ title: 'qwert' }] }
+      past: { blockingItems: [], completedItems: [{ title: 'qwert' }] },
+      notRecognized: '',
     });
   });
 });


### PR DESCRIPTION
As discussed: Changed the implementation of the library.
Compatible change: `notRecognized` is now always being returned. If everything has been recognized, this is an empty string (falsy)