### PR TITLE
[DO NOT MERGE] Refactor parsing library and use ES6.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "assistify-diary",
-  "version": "0.0.1",
+  "version": "0.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -12158,7 +12158,8 @@
     "lodash": {
       "version": "4.17.11",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+      "dev": true
     },
     "lodash._reinterpolate": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,6 @@
     "html2canvas": "^1.0.0-alpha.12",
     "jsoneditor": "^5.26.2",
     "jsoneditor-react": "^1.0.0",
-    "lodash": "^4.17.11",
     "lz-string": "^1.4.4",
     "markdown-it": "^8.4.2",
     "markdown-it-emoji": "^1.4.0",

--- a/src/client/components/UserFactsheet.jsx
+++ b/src/client/components/UserFactsheet.jsx
@@ -4,10 +4,8 @@ import Media from 'react-bulma-components/lib/components/media';
 import Heading from 'react-bulma-components/lib/components/heading';
 import User from './User';
 import Avatar from './Avatar';
-import Parser from '../lib/diaryParser';
+import { parse, renderAsText } from '../lib/diaryParser';
 import '../styles/components/UserFactSheet.scss';
-
-const parser = new Parser();
 
 export default class UserFactsheet extends React.Component {  // eslint-disable-line
   constructor(props) {
@@ -19,12 +17,12 @@ export default class UserFactsheet extends React.Component {  // eslint-disable-
 
   getTextRepresentation() {
     const { member } = this.props;
-    return parser.renderAsText(member);
+    return renderAsText(member);
   }
 
   popupTextChanged(text) {
     const { member, updateValue } = this.props;
-    Object.assign(member, parser.parse(text));
+    Object.assign(member, parse(text));
     updateValue(member.username, 'past', member.past);
     updateValue(member.username, 'future', member.future);
   }

--- a/src/client/lib/diaryParser.test.js
+++ b/src/client/lib/diaryParser.test.js
@@ -1,17 +1,17 @@
-import DiaryParser from './diaryParser';
+import { getQuestions, parse, renderAsText } from './diaryParser';
 
-const parser = new DiaryParser();
+const questions = getQuestions();
 
-const simpleText = `**${parser.questions[0]}?**
+const simpleText = `**${questions[0]}?**
 - task 1
 
-**${parser.questions[1]}?**
+**${questions[1]}?**
 - task 3
 
-**${parser.questions[2]}?**
+**${questions[2]}?**
 - task 2
 
-**${parser.questions[3]}?**
+**${questions[3]}?**
 Office`;
 
 const simpleStructure = {
@@ -22,21 +22,21 @@ const simpleStructure = {
   future: {
     plannedItems: [{ title: 'task 3' }],
     availability: 'Office'
-  }
+  },
+  notRecognized: ''
 };
 
 describe('Parser', () => {
   it('should correctly serialize the data structure', () => {
-    expect(parser.renderAsText(simpleStructure)).toEqual(simpleText);
+    expect(renderAsText(simpleStructure)).toEqual(simpleText);
   });
 
   it('should recognize the different fields in a text', () => {
-    expect(parser.parse(simpleText)).toEqual(simpleStructure);
+    expect(parse(simpleText)).toEqual(simpleStructure);
   });
 
   it('should report errors when text outside of the template is given', () => {
-    const newParser = new DiaryParser();
-    expect(newParser.parse('abc\ndef')).toEqual({
+    expect(parse('abc\ndef')).toEqual({
       future: { availability: 'unbekannt', plannedItems: [] },
       past: { blockingItems: [], completedItems: [] },
       notRecognized: 'abc\ndef'
@@ -44,19 +44,21 @@ describe('Parser', () => {
   });
 
   it('should display unformatted text below the template with a caption', () => {
-    expect(parser.renderAsText(Object.assign({ notRecognized: 'abc\ndef' }, simpleStructure)))
+    const simpleWithUnrecognized = simpleStructure;
+    simpleWithUnrecognized.notRecognized = 'abc\ndef';
+    expect(renderAsText(simpleWithUnrecognized))
       .toEqual(`${simpleText}\n&nbsp;\n**NOT RECOGNIZED**\nabc\ndef`);
   });
 
   it('should ignore case of messages', () => {
-    const newParser = new DiaryParser();
     const capitalizeEveryWord = text => text.toLowerCase()
       .split(' ')
       .map(s => s.charAt(0).toUpperCase() + s.substring(1))
       .join(' ');
-    expect(newParser.parse(`**${capitalizeEveryWord(newParser.questions[0])}?**\nqwert`)).toEqual({
+    expect(parse(`**${capitalizeEveryWord(questions[0])}?**\nqwert`)).toEqual({
       future: { availability: 'unbekannt', plannedItems: [] },
-      past: { blockingItems: [], completedItems: [{ title: 'qwert' }] }
+      past: { blockingItems: [], completedItems: [{ title: 'qwert' }] },
+      notRecognized: '',
     });
   });
 });


### PR DESCRIPTION
Move the library to ES6 modules.
However, this will result in issues for consumers not capable of using ES6: As far as I can see, we're currently *not* transpiling our code before pushing it to npm. This means, that consumers requiring the "lib" are only getting ES6 which may result in runtime errors, unless the consumer itself transpiles the code to CJS.

=> 
Either transpile this complete application before publishing to npm (a `.npmignore` has to be implemented, as well as a `prepublish` command)
OR
Extract the parser from both the projects and create a third one which only publishes the parser to NPM. @jschirrmacher wdyt?