### PR TITLE
Discussable entries

### DIFF
--- a/src/client/components/Activity.jsx
+++ b/src/client/components/Activity.jsx
@@ -9,6 +9,7 @@ import MarkDown from './Markdown';
 import User from './User';
 
 import { TeamContext } from '../lib/teamContext';
+import { DiscussItem } from './DiscussItem';
 
 function ActivityItem(props) {
   const {
@@ -33,12 +34,19 @@ function ActivityItem(props) {
     <li key={title}>
       <TeamContext.Consumer>
         {teamContext => (
-          <MarkDown
-            contentEditable={contentEditable}
-            updateValue={updateValue}
-            code={title || ''}
-            serverUrl={teamContext.serverUrl}
-          />
+          <span>
+            <MarkDown
+              contentEditable={contentEditable}
+              updateValue={updateValue}
+              code={title || ''}
+              serverUrl={teamContext.serverUrl}
+            />
+
+            <DiscussItem
+              title={title}
+              author={owners}
+            />
+          </span>
         )}
       </TeamContext.Consumer>
       {listOfOwners}

--- a/src/client/components/Activity.jsx
+++ b/src/client/components/Activity.jsx
@@ -13,7 +13,7 @@ import { DiscussItem } from './DiscussItem';
 
 function ActivityItem(props) {
   const {
-    title, owners, contentEditable, updateValue
+    title, owners, contentEditable, updateValue, displayOwners,
   } = props;
 
   const separator = <Fragment>,&nbsp;</Fragment>;
@@ -44,25 +44,26 @@ function ActivityItem(props) {
 
             <DiscussItem
               title={title}
-              author={owners}
+              authors={owners}
             />
           </span>
         )}
       </TeamContext.Consumer>
-      {listOfOwners}
+      {displayOwners && listOfOwners}
     </li>
   );
 }
 
 ActivityItem.defaultProps = {
-  owners: null
+  owners: null,
+  displayOwners: false,
 };
 
 ActivityItem.propTypes = activityItemType;
 
 export default function ActivityItems(props) {
   const {
-    title, list, className, contentEditable, updateValue
+    title, list, className, contentEditable, updateValue, displayOwners
   } = props;
 
   const titledItems = list.filter(item => item.title);
@@ -78,6 +79,7 @@ export default function ActivityItems(props) {
                 key={item.title}
                 title={item.title}
                 details={item.details}
+                displayOwners={displayOwners}
                 owners={item.owners}
                 contentEditable={contentEditable}
                 updateValue={content => updateValue(liIndex, content)}
@@ -101,12 +103,14 @@ export default function ActivityItems(props) {
 
 ActivityItems.defaultProps = {
   list: [],
+  displayOwners: false,
 };
 
 ActivityItems.propTypes = {
   title: PropTypes.string.isRequired,
   list: PropTypes.arrayOf(PropTypes.shape(activityItemType)),
   className: PropTypes.string.isRequired,
+  displayOwners: PropTypes.bool,
   contentEditable: PropTypes.bool,
   updateValue: PropTypes.func
 };

--- a/src/client/components/DetailsAggregated.jsx
+++ b/src/client/components/DetailsAggregated.jsx
@@ -46,6 +46,7 @@ export default function DetailsAggregated(props) {
       <ActivityItems
         title="Geplante Tätigkeiten"
         list={aggregatedMultipleOwners}
+        displayOwners
         className="next"
         contentEditable={false}
         updateValue={() => {}}

--- a/src/client/components/DiscussItem.jsx
+++ b/src/client/components/DiscussItem.jsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import { PropTypes } from 'prop-types';
+
+import { TeamContext } from '../lib/teamContext';
+
+export function DiscussItem(props) {
+  function getReplyUrl(serverUrl, diaryChannel, title, authors) {
+    let url = `${serverUrl}/create-thread?`;
+    let paramCount = 0;
+    if (diaryChannel) {
+      paramCount++;
+      url = `${url}${diaryChannel}`;
+    }
+
+    if (title) {
+      paramCount++;
+      url = `${url}${paramCount > 1 ? '&' : ''}message=${authors && authors.length > 0 ? `${authors.map(author => `&%40${author}`)}%0A%0A` : ''}>%20${title}%0A%0A`;
+    }
+
+    return (url);
+  }
+
+  const {
+    title,
+    authors
+  } = props;
+
+  return (
+    <TeamContext.Consumer>
+      {teamContext => (
+        <a
+          className="discuss"
+          target="blank"
+          href={getReplyUrl(teamContext.serverUrl, teamContext.diaryChannel, title, authors)}
+        >
+          <span role="img">↩</span>
+        </a>
+      )}
+    </TeamContext.Consumer>
+  );
+}
+
+DiscussItem.defaultProps = {
+  title: '',
+  authors: []
+};
+
+DiscussItem.propTypes = {
+  title: PropTypes.string,
+  authors: PropTypes.arrayOf(PropTypes.string)
+};

--- a/src/client/components/DiscussItem.jsx
+++ b/src/client/components/DiscussItem.jsx
@@ -14,7 +14,7 @@ export function DiscussItem(props) {
 
     if (title) {
       paramCount++;
-      url = `${url}${paramCount > 1 ? '&' : ''}message=${authors && authors.length > 0 ? `${authors.map(author => `&%40${author}`)}%0A%0A` : ''}>%20${title}%0A%0A`;
+      url = `${url}${paramCount > 1 ? '&' : ''}message=>%20${title}%0A%0A${authors && authors.length > 0 ? `${authors.map(author => `%40${author}`)}%20` : ''}`;
     }
 
     return (url);

--- a/src/client/components/DiscussItem.jsx
+++ b/src/client/components/DiscussItem.jsx
@@ -9,7 +9,7 @@ export function DiscussItem(props) {
     let paramCount = 0;
     if (diaryChannel) {
       paramCount++;
-      url = `${url}${diaryChannel}`;
+      url = `${url}parentChannel=${diaryChannel}`;
     }
 
     if (title) {

--- a/src/client/components/DiscussItem.jsx
+++ b/src/client/components/DiscussItem.jsx
@@ -5,19 +5,22 @@ import { TeamContext } from '../lib/teamContext';
 
 export function DiscussItem(props) {
   function getReplyUrl(serverUrl, diaryChannel, title, authors) {
-    let url = `${serverUrl}/create-thread?`;
-    let paramCount = 0;
+    const url = `${serverUrl}/create-thread`;
+    const effectiveParams = [];
+
     if (diaryChannel) {
-      paramCount++;
-      url = `${url}parentChannel=${diaryChannel}`;
+      effectiveParams.push(`parentChannel=${diaryChannel}`);
     }
 
     if (title) {
-      paramCount++;
-      url = `${url}${paramCount > 1 ? '&' : ''}message=>%20${title}%0A%0A${authors && authors.length > 0 ? `${authors.map(author => `%40${author}`)}%20` : ''}`;
+      let message = `> ${encodeURIComponent(title)}\n\n`;
+      if (authors && authors.length > 0) {
+        message += `${authors.map(author => `@${author} `)}`;
+      }
+      effectiveParams.push(`message=${encodeURIComponent(message)}`);
     }
 
-    return (url);
+    return `${url}?${effectiveParams.join('&')}`;
   }
 
   const {
@@ -30,7 +33,8 @@ export function DiscussItem(props) {
       {teamContext => (
         <a
           className="discuss"
-          target="blank"
+          rel="noopener noreferrer"
+          target="_blank"
           href={getReplyUrl(teamContext.serverUrl, teamContext.diaryChannel, title, authors)}
         >
           <span role="img">↩</span>

--- a/src/client/components/Home.jsx
+++ b/src/client/components/Home.jsx
@@ -22,7 +22,7 @@ const templateData = {
   diaryChannel: 'daily-notizen',
   teamReport: [
     {
-      username: 'Template',
+      username: 'user',
       statusKnown: true,
       past: {
         completedItems: [

--- a/src/client/components/Home.jsx
+++ b/src/client/components/Home.jsx
@@ -19,6 +19,7 @@ const templateData = {
   date: new Date(),
   teamName: 'Assistify Core',
   serverUrl: 'https://team.assistify-test.noncd.db.de',
+  diaryChannel: 'daily-notizen',
   teamReport: [
     {
       username: 'Template',
@@ -156,6 +157,7 @@ export default class Home extends Component {
           <TeamContext.Provider value={{
             teamName: diaryPage.teamName,
             serverUrl: diaryPage.serverUrl,
+            diaryChannel: diaryPage.diaryChannel,
           }}
           >
             <DiaryPage

--- a/src/client/components/Markdown.jsx
+++ b/src/client/components/Markdown.jsx
@@ -27,7 +27,7 @@ export default function Markdown(props) {
     code, withBreaks, contentEditable, updateValue
   } = props;
   return (
-    <div
+    <span
       contentEditable={contentEditable}
       onBlur={event => updateValue(event.target.innerText)}
       dangerouslySetInnerHTML={withBreaks // eslint-disable-line react/no-danger

--- a/src/client/components/MemberReport.jsx
+++ b/src/client/components/MemberReport.jsx
@@ -20,11 +20,13 @@ export default function MemberReport(props) {
   const { workingOnItems, completedItems, blockingItems } = past;
   const { plannedItems } = future;
 
-  const addOwnerToItems = function (items, owner) {
+  function addOwnerToItems(items, owner) {
     const withOwner = [];
-    items.forEach(item => withOwner.push(Object.assign({}, item, { owners: [owner] })));
+    if (items) {
+      items.forEach(item => withOwner.push(Object.assign({}, item, { owners: [owner] })));
+    }
     return withOwner;
-  };
+  }
 
   if (statusKnown) {
     return (
@@ -77,7 +79,7 @@ export default function MemberReport(props) {
               )}
             <ActivityItems
               title="Erledigt"
-              list={completedItems}
+              list={addOwnerToItems(completedItems, username)}
               className="completed"
               contentEditable={contentEditable}
               updateValue={(liIndex, title) => {
@@ -98,7 +100,7 @@ export default function MemberReport(props) {
 
             <ActivityItems
               title="Geplant"
-              list={plannedItems}
+              list={addOwnerToItems(plannedItems, username)}
               className="planned"
               contentEditable={contentEditable}
               updateValue={(liIndex, title) => {

--- a/src/client/components/MemberReport.jsx
+++ b/src/client/components/MemberReport.jsx
@@ -20,6 +20,12 @@ export default function MemberReport(props) {
   const { workingOnItems, completedItems, blockingItems } = past;
   const { plannedItems } = future;
 
+  const addOwnerToItems = function (items, owner) {
+    const withOwner = [];
+    items.forEach(item => withOwner.push(Object.assign({}, item, { owners: [owner] })));
+    return withOwner;
+  };
+
   if (statusKnown) {
     return (
       <Columns.Column renderAs="article" size={6}>
@@ -60,7 +66,7 @@ export default function MemberReport(props) {
               && (
               <ActivityItems
                 title="Blockiert"
-                list={blockingItems}
+                list={addOwnerToItems(blockingItems, username)}
                 className="blocking"
                 contentEditable={contentEditable}
                 updateValue={(liIndex, title) => {
@@ -81,7 +87,7 @@ export default function MemberReport(props) {
             />
             <ActivityItems
               title="Arbeitet an"
-              list={workingOnItems}
+              list={addOwnerToItems(workingOnItems, username)}
               className="worked-on"
               contentEditable={contentEditable}
               updateValue={(liIndex, title) => {

--- a/src/client/components/__snapshots__/Activity.test.jsx.snap
+++ b/src/client/components/__snapshots__/Activity.test.jsx.snap
@@ -28,8 +28,9 @@ exports[`renders a list correctly 1`] = `
         />
         <a
           className="discuss"
-          href="/create-thread?message=>%20sample title 1%0A%0A"
-          target="blank"
+          href="/create-thread?message=%3E%20sample%2520title%25201%0A%0A"
+          rel="noopener noreferrer"
+          target="_blank"
         >
           <span
             role="img"
@@ -52,8 +53,9 @@ exports[`renders a list correctly 1`] = `
         />
         <a
           className="discuss"
-          href="/create-thread?message=>%20sample title 2%0A%0A"
-          target="blank"
+          href="/create-thread?message=%3E%20sample%2520title%25202%0A%0A"
+          rel="noopener noreferrer"
+          target="_blank"
         >
           <span
             role="img"

--- a/src/client/components/__snapshots__/Activity.test.jsx.snap
+++ b/src/client/components/__snapshots__/Activity.test.jsx.snap
@@ -16,26 +16,52 @@ exports[`renders a list correctly 1`] = `
   </h1>
   <ul>
     <li>
-      <div
-        contentEditable={false}
-        dangerouslySetInnerHTML={
-          Object {
-            "__html": "sample title 1",
+      <span>
+        <span
+          contentEditable={false}
+          dangerouslySetInnerHTML={
+            Object {
+              "__html": "sample title 1",
+            }
           }
-        }
-        onBlur={[Function]}
-      />
+          onBlur={[Function]}
+        />
+        <a
+          className="discuss"
+          href="/create-thread?message=>%20sample title 1%0A%0A"
+          target="blank"
+        >
+          <span
+            role="img"
+          >
+            ↩
+          </span>
+        </a>
+      </span>
     </li>
     <li>
-      <div
-        contentEditable={false}
-        dangerouslySetInnerHTML={
-          Object {
-            "__html": "sample title 2",
+      <span>
+        <span
+          contentEditable={false}
+          dangerouslySetInnerHTML={
+            Object {
+              "__html": "sample title 2",
+            }
           }
-        }
-        onBlur={[Function]}
-      />
+          onBlur={[Function]}
+        />
+        <a
+          className="discuss"
+          href="/create-thread?message=>%20sample title 2%0A%0A"
+          target="blank"
+        >
+          <span
+            role="img"
+          >
+            ↩
+          </span>
+        </a>
+      </span>
     </li>
   </ul>
 </div>

--- a/src/client/components/__snapshots__/DetailsAggregated.test.jsx.snap
+++ b/src/client/components/__snapshots__/DetailsAggregated.test.jsx.snap
@@ -21,15 +21,28 @@ exports[`aggregates correctly 1`] = `
     </h1>
     <ul>
       <li>
-        <div
-          contentEditable={false}
-          dangerouslySetInnerHTML={
-            Object {
-              "__html": "planned 1",
+        <span>
+          <span
+            contentEditable={false}
+            dangerouslySetInnerHTML={
+              Object {
+                "__html": "planned 1",
+              }
             }
-          }
-          onBlur={[Function]}
-        />
+            onBlur={[Function]}
+          />
+          <a
+            className="discuss"
+            href="/create-thread?message=>%20planned 1%0A%0A%40user1,%40user2%20"
+            target="blank"
+          >
+            <span
+              role="img"
+            >
+              ↩
+            </span>
+          </a>
+        </span>
         <span>
            (
           <span>

--- a/src/client/components/__snapshots__/DetailsAggregated.test.jsx.snap
+++ b/src/client/components/__snapshots__/DetailsAggregated.test.jsx.snap
@@ -33,8 +33,9 @@ exports[`aggregates correctly 1`] = `
           />
           <a
             className="discuss"
-            href="/create-thread?message=>%20planned 1%0A%0A%40user1,%40user2%20"
-            target="blank"
+            href="/create-thread?message=%3E%20planned%25201%0A%0A%40user1%20%2C%40user2%20"
+            rel="noopener noreferrer"
+            target="_blank"
           >
             <span
               role="img"

--- a/src/client/styles/components/Activity.scss
+++ b/src/client/styles/components/Activity.scss
@@ -18,12 +18,11 @@
         // the discussion-decoration shall only be shown when hovered
         & .discuss {
             display: none;
-        }
-        &:hover .discuss {
-            // float: right;
-            display: inherit;
             margin-left: 10px;
             font-weight: bolder;
+        }
+        &:hover .discuss {
+            display: inherit;
         }
     }
 }

--- a/src/client/styles/components/Activity.scss
+++ b/src/client/styles/components/Activity.scss
@@ -1,19 +1,30 @@
-.c-activities{
+.c-activities {
     border-left: 6px solid;
     overflow: hidden;
 
-    &.worked-on{
+    &.worked-on {
         border-left-color: goldenrod;
     }
-    &.completed{
+    &.completed {
         border-left-color: rgb(3, 98, 90);
     }
-    &.blocking{
+    &.blocking {
         border-left-color: $secondary;
     }
     & li {
         margin-bottom: 10px;
         padding-left: 1.5em;
+
+        // the discussion-decoration shall only be shown when hovered
+        & .discuss {
+            display: none;
+        }
+        &:hover .discuss {
+            // float: right;
+            display: inherit;
+            margin-left: 10px;
+            font-weight: bolder;
+        }
     }
 }
 

--- a/src/models/activityItemType.js
+++ b/src/models/activityItemType.js
@@ -4,6 +4,7 @@ export const activityItemType = {
   title: PropTypes.string.isRequired,
   details: PropTypes.string,
   owners: PropTypes.arrayOf(PropTypes.string),
+  displayOwners: PropTypes.bool,
   contentEditable: PropTypes.bool,
   updateValue: PropTypes.func
 };

--- a/test/scripts/home.test.js
+++ b/test/scripts/home.test.js
@@ -25,7 +25,7 @@ test('Team overview: user1 in availability overview', async (t) => {
 
 test('Team report: Next activities', async (t) => {
   await t
-    .expect(Selector('.c-activities.next li').textContent).eql('title-planned (@user1, @user2)');
+    .expect(Selector('.c-activities.next li').textContent).eql('title-planned↩ (@user1, @user2)');
 });
 
 test('Should switch to Editor', async (t) => {


### PR DESCRIPTION
Fixes #37 

A new property `diaryChannel` is optional at the team-diary root. If it is set: The reply-thread is automatically created for the diary-channel.

When hovering on a diary-item, a reply-icon is becoming visible. Clicking on it, a new thread creation is being opened.

This is how it looks like (including the maintenance of the diary channel, which of course should be done only once):

![bildschirmaufnahme 2019-01-30 um 20 59 10 mov](https://user-images.githubusercontent.com/17176678/52009182-9a2ec800-24d2-11e9-83c1-829792a42367.gif)
