### PR TITLE
New button to send current diary URL to operations tool…

### DIFF
--- a/src/client/components/DiaryPage.jsx
+++ b/src/client/components/DiaryPage.jsx
@@ -31,7 +31,8 @@ export default class DiaryPage extends Component {
         date,
         teamName,
         teamReport,
-        serverUrl
+        serverUrl,
+        sendDiary
       }
     } = this;
 
@@ -104,6 +105,11 @@ export default class DiaryPage extends Component {
             <button type="button" id="screenshot-button" onClick={e => downloadScreenshot(e.target)}>
               <span role="img" aria-label="Screenshot">📷</span>
             </button>)}
+          {contentEditable && (
+            <button type="button" id="send-button" onClick={sendDiary}>
+              <span role="img" aria-label="Send diary">✉</span>
+            </button>
+          )}
         </Hero>
         <Availabilities
           members={teamReport}

--- a/src/client/components/Home.jsx
+++ b/src/client/components/Home.jsx
@@ -112,6 +112,14 @@ export default class Home extends Component {
     });
   }
 
+  sendDiary() {
+    const [fullMatch, sendUrl] = window.location.search.match(/edit=(.*)/);
+    if (fullMatch) {
+      const { diaryPage } = this.state;
+      window.location.href = `${sendUrl}?diaryTeam=${diaryPage.teamName}&diaryUrl=${statefulUrl.encode(diaryPage)}`;
+    }
+  }
+
   render() {
     const { diaryPage, editing } = this.state;
 
@@ -131,6 +139,7 @@ export default class Home extends Component {
               serverUrl={diaryPage.serverUrl}
               updateValue={(fieldname, value) => this.updateValue(fieldname, value)}
               contentEditable={contentEditable}
+              sendDiary={() => this.sendDiary()}
             />
           </TeamContext.Provider>
           <ReportFooter onClick={this.toggleEdit} />

--- a/src/client/components/Home.jsx
+++ b/src/client/components/Home.jsx
@@ -116,7 +116,8 @@ export default class Home extends Component {
     const [fullMatch, sendUrl] = window.location.search.match(/edit=(.*)/);
     if (fullMatch) {
       const { diaryPage } = this.state;
-      window.location.href = `${sendUrl}?diaryTeam=${diaryPage.teamName}&diaryUrl=${statefulUrl.encode(diaryPage)}`;
+      const diaryUrl = encodeURIComponent(statefulUrl.encode(diaryPage));
+      window.location.href = `${sendUrl}?diaryTeam=${diaryPage.teamName}&diaryUrl=${diaryUrl}`;
     }
   }
 

--- a/src/client/styles/index.scss
+++ b/src/client/styles/index.scss
@@ -36,5 +36,15 @@
   }
 }
 
+#send-button {
+  position: absolute;
+  right: 45px;
+  top: 10px;
+  height: 30px;
+  width: 30px;
+  font-size: 22px;
+  border-radius: 50%;
+}
+
 // elements which properties are overridden
 @import './objects/section.scss';

--- a/src/client/styles/index.scss
+++ b/src/client/styles/index.scss
@@ -23,32 +23,30 @@ body {
   margin: -1.5em 0 1.5em;
 }
 
-#screenshot-button {
+.hero button {
+  cursor: pointer;
   position: absolute;
   top: 10px;
-  right: 10px;
-  cursor: pointer;
-  width: 30px;
   height: 30px;
+  width: 30px;
   text-align: center;
   border-radius: 50%;
-  line-height: 1em;
-  text-indent: -4px;
-  font-size: 20px;
 
   &:hover {
     background-color: #cccccc;
   }
 }
 
+#screenshot-button {
+  right: 10px;
+  line-height: 1em;
+  text-indent: -4px;
+  font-size: 20px;
+}
+
 #send-button {
-  position: absolute;
   right: 45px;
-  top: 10px;
-  height: 30px;
-  width: 30px;
   font-size: 22px;
-  border-radius: 50%;
 }
 
 // elements which properties are overridden


### PR DESCRIPTION
… which sends it as a message to the team's diary channel.

This requires the `edit` parameter to be the URL of the operations tool. This is not fixed to provide using a local installation of the operations tool which is helpful when testing or if the URL of the operations tool ever changes. The operations tool knows best about it's URL at least.